### PR TITLE
Rebase v2.2.0

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,0 +1,13 @@
+# Changelog since v2.1.0
+
+### Bug Fixes
+
+- A bug that prevented the external-attacher from releasing its finalizer from a `PersistentVolume` object that was created using a legacy storage class provisioner and migrated to CSI has been fixed. ([#218](https://github.com/kubernetes-csi/external-attacher/pull/218), [@rfranzke](https://github.com/rfranzke))
+- Update package path to v2. Vendoring with dep depends on https://github.com/golang/dep/pull/1963 or the workaround described in v2/README.md. ([#209](https://github.com/kubernetes-csi/external-attacher/pull/209), [@alex1989hu](https://github.com/alex1989hu))
+
+
+### Other Notable Changes
+
+- Removed usage of annotation csi.volume.kubernetes.io/nodeid on Node objects. The external-attacher now requires Kubernetes 1.14 with feature gate CSINodeInfo enabled. ([#213](https://github.com/kubernetes-csi/external-attacher/pull/213), [@Danil-Grigorev](https://github.com/Danil-Grigorev))
+
+

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This information reflects the head of this branch.
 
 | Compatible with CSI Version                                                                | Container Image             | Min K8s Version | Recommended K8s Version |
 | ------------------------------------------------------------------------------------------ | ----------------------------| --------------- | ----------------------- |
-| [CSI Spec v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | quay.io/k8scsi/csi-attacher | 1.15            | 1.17                    |
+| [CSI Spec v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | quay.io/k8scsi/csi-attacher | 1.14            | 1.18                    |
 
 ## Feature Status
 
@@ -31,10 +31,9 @@ The following table reflects the head of this branch.
 
 | Feature       | Status  | Default | Description                                                                                   |
 | ------------- | ------- | ------- | --------------------------------------------------------------------------------------------- |
-| CSINode*      | Beta    | On      | external-attacher uses the CSINode object to get the driver's node name instead of the Node annotation. |
 | CSIMigration* | Beta    | On      | [Migrating in-tree volume plugins to CSI](https://kubernetes.io/docs/concepts/storage/volumes/#csi-migration). |
 
-*) There are no special feature gates for these features. They are enabled by turning on the corresponding features in Kubernetes.
+*) There is no special feature gate for this feature. It is enabled by turning on the corresponding features in Kubernetes.
 
 All other external-attacher features and the external-attacher itself is considered GA and fully supported.
 

--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -36,8 +36,8 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
-	"github.com/kubernetes-csi/external-attacher/pkg/controller"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/controller"
 	"google.golang.org/grpc"
 )
 
@@ -46,8 +46,7 @@ const (
 	// Default timeout of short CSI calls like GetPluginInfo
 	csiTimeout = time.Second
 
-	leaderElectionTypeLeases     = "leases"
-	leaderElectionTypeConfigMaps = "configmaps"
+	leaderElectionTypeLeases = "leases"
 )
 
 // Command line flags
@@ -155,12 +154,11 @@ func main() {
 		}
 		if supportsAttach {
 			pvLister := factory.Core().V1().PersistentVolumes().Lister()
-			nodeLister := factory.Core().V1().Nodes().Lister()
 			vaLister := factory.Storage().V1beta1().VolumeAttachments().Lister()
 			csiNodeLister := factory.Storage().V1beta1().CSINodes().Lister()
 			volAttacher := attacher.NewAttacher(csiConn)
 			CSIVolumeLister := attacher.NewVolumeLister(csiConn)
-			handler = controller.NewCSIHandler(clientset, csiAttacher, volAttacher, CSIVolumeLister, pvLister, nodeLister, csiNodeLister, vaLister, timeout, supportsReadOnly, csitrans.New())
+			handler = controller.NewCSIHandler(clientset, csiAttacher, volAttacher, CSIVolumeLister, pvLister, csiNodeLister, vaLister, timeout, supportsReadOnly, csitrans.New())
 			klog.V(2).Infof("CSI driver supports ControllerPublishUnpublish, using real CSI handler")
 		} else {
 			handler = controller.NewTrivialHandler(clientset)

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: default
 
 ---
-# Attacher must be able to work with PVs, nodes and VolumeAttachments
+# Attacher must be able to work with PVs, CSINodes and VolumeAttachments
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,9 +25,6 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]

--- a/doc/development.md
+++ b/doc/development.md
@@ -8,7 +8,7 @@ csi-attacher -kubeconfig ~/.kube/config -v 5 -csi-address /run/csi/socket
 
 ## Implementation details
 
-The external-attacher follows [controller](https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md) pattern and uses informers to watch for `VolumeAttachment` and `PersistentVolume` create/update/delete events. It filters out `VolumeAttachment` instances with `Attacher==<CSI driver name>` and processes these events in workqueues with exponential backoff. Real handling is deferred to `Handler` interface.
+The external-attacher follows [controller](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/controllers.md) pattern and uses informers to watch for `VolumeAttachment` and `PersistentVolume` create/update/delete events. It filters out `VolumeAttachment` instances with `Attacher==<CSI driver name>` and processes these events in workqueues with exponential backoff. Real handling is deferred to `Handler` interface.
 
 `Handler` interface has two implementations, trivial and real one.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/kubernetes-csi/external-attacher
+module github.com/kubernetes-csi/external-attacher/v2
 
-go 1.12
+go 1.13
 
 require (
 	github.com/container-storage-interface/spec v1.2.0

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +62,6 @@ type csiHandler struct {
 	attacher                attacher.Attacher
 	CSIVolumeLister         VolumeLister
 	pvLister                corelisters.PersistentVolumeLister
-	nodeLister              corelisters.NodeLister
 	csiNodeLister           storagelisters.CSINodeLister
 	vaLister                storagelisters.VolumeAttachmentLister
 	vaQueue, pvQueue        workqueue.RateLimitingInterface
@@ -82,7 +81,6 @@ func NewCSIHandler(
 	attacher attacher.Attacher,
 	CSIVolumeLister VolumeLister,
 	pvLister corelisters.PersistentVolumeLister,
-	nodeLister corelisters.NodeLister,
 	csiNodeLister storagelisters.CSINodeLister,
 	vaLister storagelisters.VolumeAttachmentLister,
 	timeout *time.Duration,
@@ -95,7 +93,6 @@ func NewCSIHandler(
 		attacher:                attacher,
 		CSIVolumeLister:         CSIVolumeLister,
 		pvLister:                pvLister,
-		nodeLister:              nodeLister,
 		csiNodeLister:           csiNodeLister,
 		vaLister:                vaLister,
 		timeout:                 *timeout,
@@ -188,7 +185,7 @@ func (h *csiHandler) ReconcileVA() error {
 
 // setForceSync sets the intention that next time the VolumeAttachment
 // referenced by vaName is processed on the VA queue that attach or detach will
-// proceed even when the VA.Status.Attached mayalready show the desired state
+// proceed even when the VA.Status.Attached may already show the desired state
 func (h *csiHandler) setForceSync(vaName string) {
 	h.forceSyncMux.Lock()
 	defer h.forceSyncMux.Unlock()
@@ -682,7 +679,7 @@ func (h *csiHandler) getCredentialsFromPV(csiSource *v1.CSIPersistentVolumeSourc
 	return credentials, nil
 }
 
-// getNodeID finds node ID from Node API object. If caller wants, it can find
+// getNodeID finds node ID from CSINode API object. If caller wants, it can find
 // node ID stored in VolumeAttachment annotation.
 func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.VolumeAttachment) (string, error) {
 	// Try to find CSINode first.
@@ -692,19 +689,14 @@ func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.Volum
 			klog.V(4).Infof("Found NodeID %s in CSINode %s", nodeID, nodeName)
 			return nodeID, nil
 		}
-		klog.V(4).Infof("CSINode %s does not contain driver %s", nodeName, driver)
 		// CSINode exists, but does not have the requested driver.
-		// Fall through to Node annotation.
-	} else {
-		// Can't get CSINode, fall through to Node annotation.
-		klog.V(4).Infof("Can't get CSINode %s: %s", nodeName, err)
+		errMessage := fmt.Sprintf("CSINode %s does not contain driver %s", nodeName, driver)
+		klog.V(4).Info(errMessage)
+		return "", errors.New(errMessage)
 	}
 
-	// Check Node annotation.
-	node, err := h.nodeLister.Get(nodeName)
-	if err == nil {
-		return GetNodeIDFromNode(driver, node)
-	}
+	// Can't get CSINode, check Volume Attachment.
+	klog.V(4).Infof("Can't get CSINode %s: %s", nodeName, err)
 
 	// Check VolumeAttachment annotation as the last resort if caller wants so (i.e. has provided one).
 	if va == nil {
@@ -714,7 +706,7 @@ func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.Volum
 		return nodeID, nil
 	}
 
-	// return nodeLister.Get error
+	// return csiNodeLister.Get error
 	return "", err
 }
 

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
@@ -57,7 +57,6 @@ func csiHandlerFactory(client kubernetes.Interface, informerFactory informers.Sh
 		csi,
 		lister,
 		informerFactory.Core().V1().PersistentVolumes().Lister(),
-		informerFactory.Core().V1().Nodes().Lister(),
 		informerFactory.Storage().V1beta1().CSINodes().Lister(),
 		informerFactory.Storage().V1beta1().VolumeAttachments().Lister(),
 		&timeout,
@@ -73,7 +72,6 @@ func csiHandlerFactoryNoReadOnly(client kubernetes.Interface, informerFactory in
 		csi,
 		lister,
 		informerFactory.Core().V1().PersistentVolumes().Lister(),
-		informerFactory.Core().V1().Nodes().Lister(),
 		informerFactory.Storage().V1beta1().CSINodes().Lister(),
 		informerFactory.Storage().V1beta1().VolumeAttachments().Lister(),
 		&timeout,
@@ -194,17 +192,16 @@ func node() *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNodeName,
-			Annotations: map[string]string{
-				"csi.volume.kubernetes.io/nodeid": fmt.Sprintf("{ %q: %q }", testAttacherName, testNodeID),
-			},
 		},
 	}
 }
 
-func nodeWithoutAnnotations() *v1.Node {
-	n := node()
-	n.Annotations = nil
-	return n
+func nodeWithAnnotations() *v1.Node {
+	node := node()
+	node.Annotations = map[string]string{
+		"csi.volume.kubernetes.io/nodeid": fmt.Sprintf("{ %q: %q }", testAttacherName, testNodeID),
+	}
+	return node
 }
 
 func csiNode() *storage.CSINode {
@@ -295,7 +292,7 @@ func TestCSIHandler(t *testing.T) {
 		//
 		{
 			name:           "VolumeAttachment added -> successful attachment",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false /*attached*/, "" /*finalizer*/, nil /* annotations */),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -312,7 +309,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with InlineVolumeSpec -> successful attachment",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        vaWithInlineSpec(va(false /*attached*/, "" /*finalizer*/, nil /* annotations */)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -328,7 +325,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "readOnly VolumeAttachment added -> successful attachment",
-			initialObjects: []runtime.Object{pvReadOnly(pvWithFinalizer()), node()},
+			initialObjects: []runtime.Object{pvReadOnly(pvWithFinalizer()), csiNode()},
 			addedVA:        va(false /*attached*/, "" /*finalizer*/, nil /* annotations */),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -345,7 +342,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "readOnly VolumeAttachment with InlineVolumeSpec -> successful attachment",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        vaInlineSpecReadOnly(vaWithInlineSpec(va(false /*attached*/, "" /*finalizer*/, nil /* annotations */))),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -361,7 +358,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment updated -> successful attachment",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			updatedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -378,7 +375,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with InlineVolumeSpec updated -> successful attachment",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			updatedVA:      vaWithInlineSpec(va(false /*attached*/, "" /*finalizer*/, nil /* annotations */)),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -395,7 +392,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with attributes -> successful attachment",
-			initialObjects: []runtime.Object{pvWithAttributes(pvWithFinalizer(), map[string]string{"foo": "bar"}), node()},
+			initialObjects: []runtime.Object{pvWithAttributes(pvWithFinalizer(), map[string]string{"foo": "bar"}), csiNode()},
 			updatedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -412,7 +409,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with InlineVolumeSpec and attributes -> successful attachment",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			updatedVA:      vaInlineSpecWithAttributes(vaWithInlineSpec(va(false, "", nil)) /*va*/, map[string]string{"foo": "bar"} /*attributes*/),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -429,7 +426,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with secrets -> successful attachment",
-			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "secret"), node(), secret()},
+			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "secret"), secret(), csiNode()},
 			updatedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "secret"),
@@ -447,7 +444,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with InlineVolumeSpec and secrets -> successful attachment",
-			initialObjects: []runtime.Object{node(), secret()},
+			initialObjects: []runtime.Object{secret(), csiNode()},
 			updatedVA:      vaInlineSpecWithSecret(vaWithInlineSpec(va(false, "", nil)) /*va*/, "secret" /*secret*/),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "secret"),
@@ -465,7 +462,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with empty secrets -> successful attachment",
-			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "emptySecret"), node(), emptySecret()},
+			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "emptySecret"), emptySecret(), csiNode()},
 			updatedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "emptySecret"),
@@ -483,7 +480,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with InlineVolumeSpec and empty secrets -> successful attachment",
-			initialObjects: []runtime.Object{node(), emptySecret()},
+			initialObjects: []runtime.Object{emptySecret(), csiNode()},
 			updatedVA:      vaInlineSpecWithSecret(vaWithInlineSpec(va(false, "", nil)) /*va*/, "emptySecret" /*secret*/),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "emptySecret"),
@@ -501,7 +498,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with missing secrets -> error",
-			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "unknownSecret"), node()},
+			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "unknownSecret"), csiNode()},
 			updatedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "unknownSecret"),
@@ -513,7 +510,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment updated -> PV finalizer is added",
-			initialObjects: []runtime.Object{pv(), node()},
+			initialObjects: []runtime.Object{pv(), csiNode()},
 			updatedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				// PV Finalizer after VA
@@ -534,7 +531,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "error saving PV finalizer -> controller retries",
-			initialObjects: []runtime.Object{pv(), node()},
+			initialObjects: []runtime.Object{pv(), csiNode()},
 			updatedVA:      va(false, "", nil),
 			reactors: []reaction{
 				{
@@ -586,14 +583,14 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:             "already attached volume -> ignored",
-			initialObjects:   []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects:   []runtime.Object{pvWithFinalizer(), csiNode()},
 			updatedVA:        va(true, fin, ann),
 			expectedActions:  []core.Action{},
 			expectedCSICalls: []csiCall{},
 		},
 		{
 			name:           "PV with deletion timestamp -> ignored with error",
-			initialObjects: []runtime.Object{pvDeleted(pv()), node()},
+			initialObjects: []runtime.Object{pvDeleted(pv()), csiNode()},
 			updatedVA:      va(false, fin, ann),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -604,7 +601,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment added -> successful attachment incl. metadata",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false, "", nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -620,13 +617,13 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:            "unknown driver -> ignored",
-			initialObjects:  []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects:  []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:         vaWithInvalidDriver(va(false, fin, ann)),
 			expectedActions: []core.Action{},
 		},
 		{
 			name:           "unknown PV -> error",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        va(false, fin, ann),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -636,7 +633,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "unknown PV -> error + error saving the error",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        va(false, fin, ann),
 			reactors: []reaction{
 				{
@@ -670,7 +667,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "neither PV nor InlineVolumeSpec reference-> error",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        vaWithNoPVReferenceNorInlineVolumeSpec(va(false, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -680,7 +677,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "both PV and InlineVolumeSpec reference-> error",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        vaAddInlineSpec(va(false, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -695,12 +692,12 @@ func TestCSIHandler(t *testing.T) {
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
 					types.MergePatchType, patch(va(false, fin, ann), vaWithAttachError(va(false, fin, ann),
-						"node \"node1\" not found"))),
+						"csinode.storage.k8s.io \"node1\" not found"))),
 			},
 		},
 		{
 			name:           "failed write with VA finializers -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false, "", nil),
 			reactors: []reaction{
 				{
@@ -744,7 +741,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "failed write with attached=true -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false, "", nil),
 			reactors: []reaction{
 				{
@@ -788,7 +785,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "CSI attach fails -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false, "", nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -815,7 +812,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "CSI attach times out -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false, "", nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -832,28 +829,38 @@ func TestCSIHandler(t *testing.T) {
 			},
 		},
 		{
-			name:           "Node without annotations -> error",
-			initialObjects: []runtime.Object{pvWithFinalizer(), nodeWithoutAnnotations()},
+			name:           "Node without CSINode -> error",
+			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
 			addedVA:        va(false, fin, ann),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
 					types.MergePatchType, patch(va(false /*attached*/, fin, ann),
-						vaWithAttachError(va(false, fin, ann), "node \"node1\" has no NodeID annotation"))),
+						vaWithAttachError(va(false, fin, ann), "csinode.storage.k8s.io \"node1\" not found"))),
 			},
 		},
 		{
-			name:           "CSINode exists without the driver, Node without annotations -> error",
-			initialObjects: []runtime.Object{pvWithFinalizer(), nodeWithoutAnnotations(), csiNodeEmpty()},
+			name:           "Node with annotations, CSINode is absent -> error",
+			initialObjects: []runtime.Object{pvWithFinalizer(), nodeWithAnnotations()},
 			addedVA:        va(false, fin, ann),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
 					types.MergePatchType, patch(va(false /*attached*/, fin, ann),
-						vaWithAttachError(va(false, fin, ann), "node \"node1\" has no NodeID annotation"))),
+						vaWithAttachError(va(false, fin, ann), "csinode.storage.k8s.io \"node1\" not found"))),
+			},
+		},
+		{
+			name:           "CSINode exists without the driver -> error",
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNodeEmpty()},
+			addedVA:        va(false, fin, ann),
+			expectedActions: []core.Action{
+				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
+					types.MergePatchType, patch(va(false /*attached*/, fin, ann),
+						vaWithAttachError(va(false, fin, ann), "CSINode node1 does not contain driver csi/test"))),
 			},
 		},
 		{
 			name:           "CSINode exists with the driver, Node without annotations -> success",
-			initialObjects: []runtime.Object{pvWithFinalizer(), nodeWithoutAnnotations(), csiNode()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false /*attached*/, "" /*finalizer*/, nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -870,7 +877,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with GCEPersistentDiskVolumeSource -> successful attachment",
-			initialObjects: []runtime.Object{gcePDPVWithFinalizer(), node()},
+			initialObjects: []runtime.Object{gcePDPVWithFinalizer(), csiNode()},
 			addedVA:        va(false /*attached*/, "" /*finalizer*/, nil),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -891,7 +898,7 @@ func TestCSIHandler(t *testing.T) {
 
 		{
 			name:           "VolumeAttachment marked for deletion -> successful detach",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -904,7 +911,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with InlineVolumeSpec marked for deletion -> successful detach",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        deleted(vaWithInlineSpec(va(true, fin, ann))),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -917,7 +924,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "volume with secrets -> successful detach",
-			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "secret"), node(), secret()},
+			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "secret"), secret()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "secret"),
@@ -931,7 +938,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "volume attachment with InlineVolumeSpec and secrets -> successful detach",
-			initialObjects: []runtime.Object{node(), secret()},
+			initialObjects: []runtime.Object{secret()},
 			addedVA:        deleted(vaInlineSpecWithSecret(vaWithInlineSpec(va(true, fin, ann)), "secret")),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "secret"),
@@ -945,7 +952,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "volume with empty secrets -> successful detach",
-			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "emptySecret"), node(), emptySecret()},
+			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "emptySecret"), emptySecret()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "emptySecret"),
@@ -959,7 +966,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "volume attachment with InlineVolumeSpec and empty secrets -> successful detach",
-			initialObjects: []runtime.Object{node(), emptySecret()},
+			initialObjects: []runtime.Object{emptySecret()},
 			addedVA:        deleted(vaInlineSpecWithSecret(vaWithInlineSpec(va(true, fin, ann)), "emptySecret")),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "emptySecret"),
@@ -973,7 +980,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "volume with missing secrets -> error",
-			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "unknownSecret"), node()},
+			initialObjects: []runtime.Object{pvWithSecret(pvWithFinalizer(), "unknownSecret"), csiNode()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewGetAction(secretGroupResourceVersion, "default", "unknownSecret"),
@@ -986,7 +993,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "CSI detach fails with an error -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -1003,7 +1010,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "CSI detach times out -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -1017,14 +1024,14 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:             "already detached volume -> ignored",
-			initialObjects:   []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects:   []runtime.Object{pvWithFinalizer(), csiNode()},
 			updatedVA:        deleted(va(false, "", nil)),
 			expectedActions:  []core.Action{},
 			expectedCSICalls: []csiCall{},
 		},
 		{
 			name:           "detach unknown PV -> error",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        deleted(va(true, fin, ann)),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -1034,7 +1041,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "detach unknown PV -> error + error saving the error",
-			initialObjects: []runtime.Object{node()},
+			initialObjects: []runtime.Object{csiNode()},
 			addedVA:        deleted(va(true, fin, ann)),
 			reactors: []reaction{
 				{
@@ -1068,7 +1075,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "detach VA with neither PV nor InlineCSIVolumeSource reference-> error",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        deleted(vaWithNoPVReferenceNorInlineVolumeSpec(va(true, fin, ann))),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -1079,7 +1086,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "detach VA with both PV and InlineCSIVolumeSource reference-> error",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        deleted(vaAddInlineSpec(va(true, fin, ann))),
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -1095,7 +1102,7 @@ func TestCSIHandler(t *testing.T) {
 			expectedActions: []core.Action{
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
 					types.MergePatchType, patch(deleted(va(true, fin, nil)),
-						deleted(vaWithDetachError(va(true, fin, nil), "node \"node1\" not found")))),
+						deleted(vaWithDetachError(va(true, fin, nil), "csinode.storage.k8s.io \"node1\" not found")))),
 			},
 		},
 		{
@@ -1113,21 +1120,8 @@ func TestCSIHandler(t *testing.T) {
 			},
 		},
 		{
-			name:           "VolumeAttachment marked for deletion -> node is preferred over VA annotation for NodeID",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
-			addedVA:        deleted(va(true, fin, map[string]string{vaNodeIDAnnotation: "annotatedNodeID"})),
-			expectedActions: []core.Action{
-				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
-					types.MergePatchType, patch(deleted(va(true, fin, map[string]string{vaNodeIDAnnotation: "annotatedNodeID"})),
-						deleted(va(false /*attached*/, "", map[string]string{vaNodeIDAnnotation: "annotatedNodeID"})))),
-			},
-			expectedCSICalls: []csiCall{
-				{"detach", testVolumeHandle, testNodeID, noAttrs, noSecrets, readWrite, success, detached, noMetadata, 0},
-			},
-		},
-		{
 			name:           "failed write with attached=false -> controller retries",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        deleted(va(false, fin, ann)),
 			reactors: []reaction{
 				{
@@ -1170,7 +1164,7 @@ func TestCSIHandler(t *testing.T) {
 		},
 		{
 			name:           "VolumeAttachment with GCEPersistentDiskVolumeSource marked for deletion -> successful detach",
-			initialObjects: []runtime.Object{gcePDPVWithFinalizer(), node()},
+			initialObjects: []runtime.Object{gcePDPVWithFinalizer(), csiNode()},
 			addedVA:        deleted(va(true /*attached*/, fin /*finalizer*/, ann)),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -1196,6 +1190,26 @@ func TestCSIHandler(t *testing.T) {
 					types.MergePatchType, patch(pvDeleted(pvWithFinalizer()),
 						pvDeleted(pv()))),
 			},
+		},
+		{
+			name:           "VA deleted -> PV finalizer removed (GCE PD PV)",
+			initialObjects: []runtime.Object{pvDeleted(gcePDPVWithFinalizer())},
+			deletedVA:      va(false, "", nil),
+			expectedActions: []core.Action{
+				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
+					types.MergePatchType, patch(pvDeleted(gcePDPVWithFinalizer()),
+						pvDeleted(gcePDPV()))),
+			},
+		},
+		{
+			name:           "VA deleted -> PV finalizer not removed",
+			initialObjects: []runtime.Object{pvDeleted(pv())},
+			deletedVA:      va(false, "", nil),
+		},
+		{
+			name:           "VA deleted -> PV finalizer not removed (GCE PD PV)",
+			initialObjects: []runtime.Object{pvDeleted(gcePDPV())},
+			deletedVA:      va(false, "", nil),
 		},
 		{
 			name:           "PV updated -> PV finalizer removed",
@@ -1354,7 +1368,7 @@ func TestCSIHandlerReadOnly(t *testing.T) {
 		//
 		{
 			name:           "read-write PV -> attached as read-write",
-			initialObjects: []runtime.Object{pvWithFinalizer(), node()},
+			initialObjects: []runtime.Object{pvWithFinalizer(), csiNode()},
 			addedVA:        va(false /*attached*/, "" /*finalizer*/, nil /* annotations */),
 			expectedActions: []core.Action{
 				// Finalizer is saved first
@@ -1371,7 +1385,7 @@ func TestCSIHandlerReadOnly(t *testing.T) {
 		},
 		{
 			name:           "read-only PV -> attached as read-write",
-			initialObjects: []runtime.Object{pvReadOnly(pvWithFinalizer()), node()},
+			initialObjects: []runtime.Object{pvReadOnly(pvWithFinalizer()), csiNode()},
 			addedVA:        va(false /*attached*/, "" /*finalizer*/, nil /* annotations */),
 			expectedActions: []core.Action{
 				// Finalizer is saved first

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"

--- a/pkg/controller/trivial_handler.go
+++ b/pkg/controller/trivial_handler.go
@@ -25,7 +25,7 @@ import (
 )
 
 // trivialHandler is a handler that marks all VolumeAttachments as attached.
-// It's used for CSI drivers that don't support ControllerPulishVolume call.
+// It's used for CSI drivers that don't support ControllerPublishVolume call.
 // It uses no finalizer, deletion of VolumeAttachment is instant (as there is
 // nothing to detach).
 type trivialHandler struct {

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 
 	storage "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/evanphx/json-patch"
-	"k8s.io/api/core/v1"
+	jsonpatch "github.com/evanphx/json-patch"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -93,7 +93,6 @@ func markAsDetached(client kubernetes.Interface, va *storage.VolumeAttachment) (
 
 const (
 	defaultFSType              = "ext4"
-	nodeIDAnnotation           = "csi.volume.kubernetes.io/nodeid"
 	csiVolAttribsAnnotationKey = "csi.volume.kubernetes.io/volume-attributes"
 	vaNodeIDAnnotation         = "csi.alpha.kubernetes.io/node-id"
 )
@@ -112,25 +111,6 @@ func SanitizeDriverName(driver string) string {
 // GetFinalizerName returns Attacher name suitable to be used as finalizer
 func GetFinalizerName(driver string) string {
 	return "external-attacher/" + SanitizeDriverName(driver)
-}
-
-// GetNodeIDFromNode returns nodeID string from node annotations.
-func GetNodeIDFromNode(driver string, node *v1.Node) (string, error) {
-	nodeIDJSON, ok := node.Annotations[nodeIDAnnotation]
-	if !ok {
-		return "", fmt.Errorf("node %q has no NodeID annotation", node.Name)
-	}
-
-	var nodeIDs map[string]string
-	if err := json.Unmarshal([]byte(nodeIDJSON), &nodeIDs); err != nil {
-		return "", fmt.Errorf("cannot parse NodeID annotation on node %q: %s", node.Name, err)
-	}
-	nodeID, ok := nodeIDs[driver]
-	if !ok {
-		return "", fmt.Errorf("cannot find NodeID for driver %q for node %q", driver, node.Name)
-	}
-
-	return nodeID, nil
 }
 
 // GetNodeIDFromCSINode returns nodeID from CSIDriverInfoSpec

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -20,77 +20,12 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
 	driverName = "foo/bar"
 )
-
-func TestGetNodeIDFromNode(t *testing.T) {
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		expectedID  string
-		expectError bool
-	}{
-		{
-			name:        "single key",
-			annotations: map[string]string{"csi.volume.kubernetes.io/nodeid": "{\"foo/bar\": \"MyNodeID\"}"},
-			expectedID:  "MyNodeID",
-			expectError: false,
-		},
-		{
-			name: "multiple keys",
-			annotations: map[string]string{
-				"csi.volume.kubernetes.io/nodeid": "{\"foo/bar\": \"MyNodeID\", \"-foo/bar\": \"MyNodeID2\", \"foo/bar-\": \"MyNodeID3\"}",
-			},
-			expectedID:  "MyNodeID",
-			expectError: false,
-		},
-		{
-			name:        "no annotations",
-			annotations: nil,
-			expectedID:  "",
-			expectError: true,
-		},
-		{
-			name:        "invalid JSON",
-			annotations: map[string]string{"csi.volume.kubernetes.io/nodeid": "\"foo/bar\": \"MyNodeID\""},
-			expectedID:  "",
-			expectError: true,
-		},
-		{
-			name: "annotations for another driver",
-			annotations: map[string]string{
-				"csi.volume.kubernetes.io/nodeid": "{\"-foo/bar\": \"MyNodeID2\", \"foo/bar-\": \"MyNodeID3\"}",
-			},
-			expectedID:  "",
-			expectError: true,
-		},
-	}
-
-	for _, test := range tests {
-		node := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "abc",
-				Annotations: test.annotations,
-			},
-		}
-		nodeID, err := GetNodeIDFromNode(driverName, node)
-
-		if err == nil && test.expectError {
-			t.Errorf("test %s: expected error, got none", test.name)
-		}
-		if err != nil && !test.expectError {
-			t.Errorf("test %s: got error: %s", test.name, err)
-		}
-		if !test.expectError && nodeID != test.expectedID {
-			t.Errorf("test %s: unexpected NodeID: %s", test.name, nodeID)
-		}
-	}
-}
 
 func createBlockCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
 	return &csi.VolumeCapability{
@@ -171,7 +106,7 @@ func TestGetVolumeCapabilities(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name:               "RWX + anytyhing",
+			name:               "RWX + anything",
 			modes:              []v1.PersistentVolumeAccessMode{v1.ReadWriteMany, v1.ReadOnlyMany, v1.ReadWriteOnce},
 			expectedCapability: createMountCapability(defaultFSType, csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER, nil),
 			expectError:        false,

--- a/release-tools/README.md
+++ b/release-tools/README.md
@@ -81,7 +81,7 @@ on what is enabled in Prow, see
 https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-csi
 
 Test results for periodic jobs are visible in
-https://testgrid.k8s.io/sig-storage-csi
+https://testgrid.k8s.io/sig-storage-csi-ci
 
 It is possible to reproduce the Prow testing locally on a suitable machine:
 - Linux host
@@ -141,17 +141,6 @@ The `vendor` directory is optional. It is still present in projects
 because it avoids downloading sources during CI builds. If this is no
 longer deemed necessary, then a project can also remove the directory.
 
-When using packages that are part of the Kubernetes source code, the
-commands above are not enough because the [lack of semantic
-versioning](https://github.com/kubernetes/kubernetes/issues/72638)
-prevents `go mod` from finding newer releases. Importing directly from
-`kubernetes/kubernetes` also needs `replace` statements to override
-the fake `v0.0.0` versions
-(https://github.com/kubernetes/kubernetes/issues/79384). The
-`go-get-kubernetes.sh` script can be used to update all packages in
-lockstep to a different Kubernetes version. It takes a single version
-number like "1.16.0".
-
 Conversion of a repository that uses `dep` to `go mod` can be done with:
 
     GO111MODULE=on go mod init
@@ -160,3 +149,18 @@ Conversion of a repository that uses `dep` to `go mod` can be done with:
     GO111MODULE=on go mod vendor
     git rm -f Gopkg.toml Gopkg.lock
     git add go.mod go.sum vendor
+
+### Updating Kubernetes dependencies
+
+When using packages that are part of the Kubernetes source code, the
+commands above are not enough because the [lack of semantic
+versioning](https://github.com/kubernetes/kubernetes/issues/72638)
+prevents `go mod` from finding newer releases. Importing directly from
+`kubernetes/kubernetes` also needs `replace` statements to override
+the fake `v0.0.0` versions
+(https://github.com/kubernetes/kubernetes/issues/79384). The
+`go-get-kubernetes.sh` script can be used to update all packages in
+lockstep to a different Kubernetes version. Example usage:
+```
+$ ./release-tools/go-get-kubernetes.sh 1.16.4
+```

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -1,0 +1,90 @@
+# Sidecar Release Process
+
+This page describes the process for releasing a kubernetes-csi sidecar.
+
+## Prerequisites
+
+The release manager must:
+
+* Be a member of the kubernetes-csi organization. Open an
+  [issue](https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-membership&template=membership.md&title=REQUEST%3A+New+membership+for+%3Cyour-GH-handle%3E) in
+  kubernetes/org to request membership
+* Be a top level approver for the repository. To become a top level approver,
+  the candidate must demonstrate ownership and deep knowledge of the repository
+  through active maintainence, responding to and fixing issues, reviewing PRs,
+  test triage.
+* Be part of the maintainers or admin group for the repository. admin is a
+  superset of maintainers, only maintainers level is required for cutting a
+  release.  Membership can be requested by submitting a PR to kubernetes/org.
+  [Example](https://github.com/kubernetes/org/pull/1467)
+
+## Updating CI Jobs
+Whenever a new Kubernetes minor version is released, our kubernetes-csi CI jobs
+must be updated.
+
+[Our CI jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) have the
+naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
+
+1. Jobs should be actively monitored to find and fix failures in sidecars and
+   infrastructure changes early in the development cycle. Test failures are sent
+   to kubernetes-sig-storage-test-failures@googlegroups.com.
+1. "-on-master" jobs are the closest reflection to the new Kubernetes version.
+1. Fixes to our prow.sh CI script can be tested in the [CSI hostpath
+   repo](https://github.com/kubernetes-csi/csi-driver-host-path) by modifying
+   [prow.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/release-tools/prow.sh)
+   along with any overrides in
+   [.prow.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/.prow.sh)
+   to mirror the failing environment. Once e2e tests are passing (verify-unit tests
+   will fail), then the prow.sh changes can be submitted to [csi-release-tools](https://github.com/kubernetes-csi/csi-release-tools).
+1. Changes can then be updated in all the sidecar repos and hostpath driver repo
+   by following the [update
+   instructions](https://github.com/kubernetes-csi/csi-release-tools/blob/master/README.md#sharing-and-updating).
+1. New pull and CI jobs are configured by
+   [gen-jobs.sh](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/gen-jobs.sh).
+   New pull jobs that have been unverified should be initially made optional.
+   [Example](https://github.com/kubernetes/test-infra/pull/15055)
+1. Once new pull and CI jobs have been verified, and the new Kubernetes version
+   is released, we can make the optional jobs required, and also remove the
+   Kubernetes versions that are no longer supported.
+
+## Release Process
+1. Identify all issues and ongoing PRs that should go into the release, and
+  drive them to resolution.
+1. Download [K8s release notes
+  generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
+1. Generate release notes for the release. Replace arguments with the relevant
+  information.
+    ```
+    GITHUB_TOKEN=<token> ./release-notes --start-sha=0ed6978fd199e3ca10326b82b4b8b8e916211c9b --end-sha=3cb3d2f18ed8cb40371c6d8886edcabd1f27e7b9 \
+    --github-org=kubernetes-csi --github-repo=external-attacher -branch=master -output out.md
+    ```
+    * `--start-sha` should point to the last release from the same branch. For
+    example:
+        * `1.X-1.0` tag when releasing `1.X.0`
+        * `1.X.Y-1` tag when releasing `1.X.Y`
+1. Compare the generated output to the new commits for the release to check if
+   any notable change missed a release note.
+1. Reword release notes as needed. Make sure to check notes for breaking
+   changes and deprecations.
+1. If release is a new major/minor version, create a new `CHANGELOG-<major>.<minor>.md`
+   file. Otherwise, add the release notes to the top of the existing CHANGELOG
+   file for that minor version.
+1. Submit a PR for the CHANGELOG changes.
+1. Submit a PR for README changes, in particular, Compatibility, Feature status,
+   and any other sections that may need updating.
+1. Check that all [canary CI
+  jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) are passing,
+  and that test coverage is adequate for the changes that are going into the release.
+1. Make sure that no new PRs have merged in the meantime, and no PRs are in
+   flight and soon to be merged.
+1. Create a new release following a previous release as a template. Be sure to select the correct
+   branch. This requires Github release permissions as required by the prerequisites.
+   [external-provisioner example](https://github.com/kubernetes-csi/external-provisioner/releases/new)
+1. If release was a new major/minor version, create a new `release-<minor>`
+   branch at that commit.
+1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar
+   and feature pages with the new released version.
+1. After all the sidecars have been released, update
+   CSI hostpath driver with the new sidecars in the [CSI repo](https://github.com/kubernetes-csi/csi-driver-host-path/tree/master/deploy)
+   and [k/k
+   in-tree](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/testing-manifests/storage-csi/hostpath/hostpath)

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -70,6 +70,7 @@ build-%: check-go-version-go
 	CGO_ENABLED=0 GOOS=linux go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
 	if [ "$$ARCH" = "amd64" ]; then \
 		CGO_ENABLED=0 GOOS=windows go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$* ; \
+		CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*-ppc64le ./cmd/$* ; \
 	fi
 
 container-%: build-%
@@ -112,7 +113,7 @@ test-go:
 test: test-vet
 test-vet:
 	@ echo; echo "### $@:"
-	go test $(GOFLAGS_VENDOR) `go list $(GOFLAGS_VENDOR) ./... | grep -v vendor $(TEST_VET_FILTER_CMD)`
+	go vet $(GOFLAGS_VENDOR) `go list $(GOFLAGS_VENDOR) ./... | grep -v vendor $(TEST_VET_FILTER_CMD)`
 
 .PHONY: test-fmt
 test: test-fmt

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,18 @@
+This directory mirrors the source code via symlinks.
+This makes it possible to vendor v2.x releases of
+external-attacher with `dep` versions that do not
+support semantic imports. Support for that is currently
+[pending in dep](https://github.com/golang/dep/pull/1963).
+
+If users of dep have enabled pruning, they must disable if
+for external-attacher in their Gopk.toml, like this:
+
+```toml
+[prune]
+  go-tests = true
+  unused-packages = true
+
+  [[prune.project]]
+    name = "github.com/kubernetes-csi/external-attacher"
+    unused-packages = false
+```

--- a/v2/cmd/csi-attacher/main.go
+++ b/v2/cmd/csi-attacher/main.go
@@ -1,0 +1,1 @@
+../../../cmd/csi-attacher/main.go

--- a/v2/pkg/attacher/attacher.go
+++ b/v2/pkg/attacher/attacher.go
@@ -1,0 +1,1 @@
+../../../pkg/attacher/attacher.go

--- a/v2/pkg/attacher/attacher_test.go
+++ b/v2/pkg/attacher/attacher_test.go
@@ -1,0 +1,1 @@
+../../../pkg/attacher/attacher_test.go

--- a/v2/pkg/attacher/lister.go
+++ b/v2/pkg/attacher/lister.go
@@ -1,0 +1,1 @@
+../../../pkg/attacher/lister.go

--- a/v2/pkg/controller/controller.go
+++ b/v2/pkg/controller/controller.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/controller.go

--- a/v2/pkg/controller/controller_test.go
+++ b/v2/pkg/controller/controller_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/controller_test.go

--- a/v2/pkg/controller/csi_handler.go
+++ b/v2/pkg/controller/csi_handler.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/csi_handler.go

--- a/v2/pkg/controller/csi_handler_test.go
+++ b/v2/pkg/controller/csi_handler_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/csi_handler_test.go

--- a/v2/pkg/controller/framework_test.go
+++ b/v2/pkg/controller/framework_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/framework_test.go

--- a/v2/pkg/controller/trivial_handler.go
+++ b/v2/pkg/controller/trivial_handler.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/trivial_handler.go

--- a/v2/pkg/controller/trivial_handler_test.go
+++ b/v2/pkg/controller/trivial_handler_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/trivial_handler_test.go

--- a/v2/pkg/controller/util.go
+++ b/v2/pkg/controller/util.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/util.go

--- a/v2/pkg/controller/util_test.go
+++ b/v2/pkg/controller/util_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/util_test.go


### PR DESCRIPTION
Rebase to v2.2.0 for OCP 4.5.

Diff to upstream v2.2.0:
https://github.com/kubernetes-csi/external-attacher/compare/v2.2.0...jsafrane:rebase-v2.2.0

@openshift/storage