### PR TITLE
UPSTREAM: 379: Fix gofmt for go 1.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/kubernetes-csi/external-attacher
 COPY . .
 RUN make build

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (


### PR DESCRIPTION
Fix gofmt issue from https://github.com/kubernetes-csi/external-attacher/pull/379 + updating csi-attacher images to be consistent with ART.

@openshift/storage 