### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - release-tools/**


### PR DESCRIPTION
Ignore these errors, release-tools is not part of the component that runs in production, and these reported issues do not grant the caller any extra permissions. If you can read it with release-tools then you already have access to read it without release-tools.

```
 ✗ [Medium] Path Traversal
   ID: 97a9b28d-b0b5-440d-aa90-0b2c5f15562d 
   Path: release-tools/boilerplate/boilerplate.py, line 59 
   Info: Unsanitized input from a command line argument flows into open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: e3e1e7bf-77ea-4e38-92f4-df6bdc56d816 
   Path: release-tools/boilerplate/boilerplate.py, line 150 
   Info: Unsanitized input from a command line argument flows into os.walk, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: 6cf8fba1-f5a7-4cde-95a6-2ec9cce4e58d 
   Path: release-tools/filter-junit.go, line 98 
   Info: Unsanitized input from a CLI argument flows into os.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: 8dea6e44-71f0-41b3-ba4d-1d3168060295 
   Path: release-tools/filter-junit.go, line 145 
   Info: Unsanitized input from a CLI argument flows into os.WriteFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to write arbitrary files.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-csi-external-attacher-master-security/1745954199155249152

/cc @openshift/storage
