### PR TITLE
Dockerfile remove

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,8 +1,0 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
-WORKDIR /go/src/github.com/kubernetes-csi/external-attacher
-COPY . .
-RUN make build
-
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.7:base
-COPY --from=builder /go/src/github.com/kubernetes-csi/external-attacher/bin/csi-attacher /usr/bin/
-ENTRYPOINT ["/usr/bin/csi-attacher"]


### PR DESCRIPTION
Remove deprecated dockerfile.openshift

We can possibly add it to rebase also since it's still not merged.

@openshift/storage 