### PR TITLE
OCPBUGS-61394: UPSTREAM: 682: Skip VolumeAttachments of other drivers

### DIFF
--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -138,6 +138,11 @@ func (h *csiHandler) ReconcileVA(ctx context.Context) error {
 	}
 
 	for _, va := range vas {
+		if va.Spec.Attacher != h.attacherName {
+			// skip VolumeAttachments of other CSI drivers
+			continue
+		}
+
 		nodeID, err := h.getNodeID(logger, h.attacherName, va.Spec.NodeName, va)
 		if err != nil {
 			logger.Error(err, "Failed to find node ID err")


### PR DESCRIPTION
During periodic re-sync in ReconcileVA, skip VolumeAttachments of unrelated CSI drivers. The VolumeAttachments will be skipped anyway in syncVA().

This only prevents log spam and saves some CPU.

cc @openshift/storage 